### PR TITLE
Fix issue of Atom hanging when loading a groovy file

### DIFF
--- a/grammars/groovy.cson
+++ b/grammars/groovy.cson
@@ -782,16 +782,17 @@
         ]
       }
     ]
-  'methods':
-    'applyEndPatternLast': 1
-    'begin': '(?x:(?<=;|^|{)(?=\\s*\n                (?:\n                    (?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final) # visibility/modifier\n                        |\n                    (?:def)\n                        |\n                    (?:\n                        (?:\n                            (?:void|boolean|byte|char|short|int|float|long|double)\n                                |\n                            (?:@?(?:[a-zA-Z]\\w*\\.)*[A-Z]+\\w*) # object type\n                        )\n                        [\\[\\]]*\n                        (?:<.*>)?\n                    ) \n                    \n                )\n                \\s+\n                ([^=]+\\s+)?\\w+\\s*\\(\n\t\t\t))'
-    'end': '}|(?=[^{])'
-    'name': 'meta.definition.method.groovy'
-    'patterns': [
-      {
-        'include': '#method-content'
-      }
-    ]
+  #This appears to match methods correclty, but you lose formatting of words like 'public' when it does
+  #'methods':
+  #  'applyEndPatternLast': 1
+  #  'begin': '(?x:(?<=;|^|{)(?=\\s*(?:(?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final)?)|(?:def)|(?:(?:(?:void|boolean|byte|char|short|int|float|long|double)|(?:@?(?:[a-zA-Z]\\w*\\.)*[A-Z]+\\w*))[\\[\\]]*(?:<.*>)?) )\\s+([^=]+\\s+)?\\w+\\s*\\(\n\t\t\t)'
+  #  'end': '}|(?=[^{])'
+  #  'name': 'meta.definition.method.groovy'
+  #  'patterns': [
+  #    {
+  #      'include': '#method-content'
+  #    }
+  #  ]
   'nest_curly':
     'begin': '\\{'
     'captures':
@@ -1164,7 +1165,7 @@
     'applyEndPatternLast': 1
     'patterns': [
       {
-        'begin': '(?x:(?=\n                        (?:\n                            (?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final) # visibility/modifier\n                                |\n                            (?:def)\n                                |\n                            (?:void|boolean|byte|char|short|int|float|long|double)\n                                |\n                            (?:(?:[a-z]\\w*\\.)*[A-Z]+\\w*) # object type\n                        )\n                        \\s+\n                        [\\w\\d_<>\\[\\],\\s]+\n                        (?:=|$)\n                        \n        \t\t\t))'
+        'begin': '(?x:(?=(?:(?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final)|(?:def)|(?:void|boolean|byte|char|short|int|float|long|double)|(?:(?:[a-z]\\w*\\.)*[A-Z]+\\w*))\\s+[\\w\\d_<>\\[\\],\\s]+(?:=|$)\t\t\t))'
         'end': ';|$'
         'name': 'meta.definition.variable.groovy'
         'patterns': [


### PR DESCRIPTION
The current code causes Atom to hang when trying to parse most groovy files.  It looks like the regexes for variables and methods were copied from a multiline string that had a bunch of comments, new lines and spaces in them.  

I've resolved the big issues with both regexes, however, when Atom matches the method, it stops highlighting keywords in the method declaration, so I've commented out the method block for now.  I honestly don't know if the methods block adds anything to Atom, but I didn't notice any special treatment when I had it enabled.

This will resolve the immediate issue of hanging and still allow the keywords to be highlighted.  
