### PR TITLE
Add the 'trait' keyword

### DIFF
--- a/grammars/groovy.cson
+++ b/grammars/groovy.cson
@@ -212,7 +212,7 @@
       }
     ]
   'class':
-    'begin': '(?=\\w?[\\w\\s]*(?:class|(?:@)?interface|enum)\\s+\\w+)'
+    'begin': '(?=\\w?[\\w\\s]*(?:class|trait|(?:@)?interface|enum)\\s+\\w+)'
     'end': '}'
     'endCaptures':
       '0':
@@ -231,7 +231,7 @@
             'name': 'storage.modifier.groovy'
           '2':
             'name': 'entity.name.type.class.groovy'
-        'match': '(class|(?:@)?interface|enum)\\s+(\\w+)'
+        'match': '(class|trait|(?:@)?interface|enum)\\s+(\\w+)'
         'name': 'meta.class.identifier.groovy'
       }
       {


### PR DESCRIPTION
Groovy 2.3 introduced the notion of 'traits' for composition of behavior.
A new keyword 'trait' was created and should be highlighted similarly to 'class', 'interface' or 'enum'.
