### PR TITLE
Specify commentStart for toggle-line-comments.

### DIFF
--- a/scoped-properties/language-groovy.json
+++ b/scoped-properties/language-groovy.json
@@ -1,0 +1,7 @@
+{
+  ".source.groovy": {
+    "editor": {
+      "commentStart": "// "
+    }
+  }
+}


### PR DESCRIPTION
The commentStart prefix must be set for the editor:toggle-line-comments
command to use single-line comments.  Without this setting, it will
default to wrapping the entire selection with /\* */.
