### PR TITLE
Adding Coffeelint and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+node_js: "iojs"
+
+install: npm install -g coffeelint
+
+script: coffeelint grammars/groovy.cson settings/language-groovy.cson snippets/language-groovy.cson

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,37 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
+    },
+    "level": "error"
+  },
+  "braces_spacing": {
+    "spaces": 0,
+    "level": "error"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  }
+}

--- a/settings/language-groovy.cson
+++ b/settings/language-groovy.cson
@@ -1,0 +1,3 @@
+'.source.groovy':
+  'editor':
+    'commentStart': '// '

--- a/settings/language-groovy.json
+++ b/settings/language-groovy.json
@@ -1,7 +1,0 @@
-{
-  ".source.groovy": {
-    "editor": {
-      "commentStart": "// "
-    }
-  }
-}


### PR DESCRIPTION
**Commit Overview**
* adds Coffeescript lint checking
  - uses configuration from [atom](https://github.com/atom/atom/blob/master/coffeelint.json)
* adds Travis CI continuous testing / integration
  - requires some [setup to enable Travis CI](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in)
  - produces a build log for each commit/PR that [looks like this](https://travis-ci.org/ChristianMurphy/language-groovy)