### PR TITLE
add increaseIndentPattern and decreaseIndentPattern to settings

### DIFF
--- a/settings/language-groovy.cson
+++ b/settings/language-groovy.cson
@@ -1,3 +1,11 @@
 '.source.groovy':
   'editor':
     'commentStart': '// '
+    'increaseIndentPattern': '(?x)
+        \\{ [^}"\']* $
+      | \\[ [^\\]"\']* $
+      | \\( [^)"\']* $
+      '
+    'decreaseIndentPattern': '(?x)
+        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]
+      '


### PR DESCRIPTION
so atom will indent appropriately at times

Just started using this package and noticed that atom wouldn't tab at times like other language packages.  Mainly after statements that you would expect it to indent the next line like after a for statement (while, if, switch, etc.)  So I made a small change by copying what the language-javascript package does to achieve this.

I suppose that could of been left out on purpose but I tend to prefer the auto-indentation. 