### PR TITLE
Enabled groovy syntax highlighting for Jenkinsfile

### DIFF
--- a/grammars/groovy.cson
+++ b/grammars/groovy.cson
@@ -2,6 +2,7 @@
   'groovy'
   'gvy'
   'gradle'
+  'Jenkinsfile'
 ]
 'foldingStartMarker': '(\\{\\s*$|^\\s*// \\{\\{\\{)'
 'foldingStopMarker': '^\\s*(\\}|// \\}\\}\\}$)'


### PR DESCRIPTION
Hello,
Would be nice to have auto detection of groovy syntax for [Jenkinsfile](https://jenkins-ci.org/blog/2015/12/03/pipeline-as-code-with-multibranch-workflows-in-jenkins/). `Jenkinsfile` is going to be a kind of "Thing" in Jenkins community. And Jenkinsfile is in fact a groovy script.